### PR TITLE
[BUG--FIX] issue 32: setup command fails to get az cli version

### DIFF
--- a/src/commands/setup.test.ts
+++ b/src/commands/setup.test.ts
@@ -428,10 +428,7 @@ describe("test getAPIClients function", () => {
 
 describe("test isAzCLIInstall function", () => {
   it("positive test", async () => {
-    const version = JSON.stringify({
-      "azure-cli": "2.0.79",
-    });
-    jest.spyOn(shell, "exec").mockResolvedValueOnce(version);
+    jest.spyOn(shell, "exec").mockResolvedValueOnce("azure-cli    2.5.0");
     await isAzCLIInstall();
   });
   it("negative test: version is not returned", async () => {

--- a/src/commands/setup.ts
+++ b/src/commands/setup.ts
@@ -64,14 +64,19 @@ interface APIClients {
 
 export const isAzCLIInstall = async (): Promise<void> => {
   try {
-    const result = await exec("az", ["version"]);
-    try {
-      logger.info(`az cli vesion ${JSON.parse(result)["azure-cli"]}`);
-    } catch (e) {
+    const result = await exec("az", ["--version"]);
+    const ver = result
+      .split("\n")
+      .find((s) => s.startsWith("azure-cli "))
+      ?.split(/\s+/);
+    const version = ver && ver.length === 2 ? ver[1] : null;
+
+    if (version) {
+      logger.info(`az cli vesion ${version}`);
+    } else {
       throw buildError(
         errorStatusCode.ENV_SETTING_ERR,
-        "setup-cmd-az-cli-get-version-err",
-        e
+        "setup-cmd-az-cli-parse-az-version-err"
       );
     }
   } catch (err) {

--- a/src/lib/i18n.json
+++ b/src/lib/i18n.json
@@ -23,6 +23,7 @@
 
     "setup-cmd-failed": "Setup command was not successfully executed.",
     "setup-cmd-az-cli-err": "az command line was not installed.",
+    "setup-cmd-az-cli-parse-az-version-err": "Could not determine az cli version, the installed azure cli might not be supported.",
     "setup-cmd-prompt-err-no-subscriptions": "No subscriptions found.",
     "setup-cmd-prompt-err-subscription-missing": "Subscription Identifier was missing.",
     "setup-cmd-prompt-err-input-file-missing": "{0} did not exist or not accessible. Make sure that it is accessible.",


### PR DESCRIPTION
change the code to call `az --version` insteads of `az install`. the latter returns a JSON; and the format does not. Hence added code to perform string parsing.

closes https://github.com/microsoft/bedrock-cli/issues/32