### PR TITLE
[BUG_FIX] issue 34 bedrock setup command failure for some az cli version

### DIFF
--- a/src/commands/setup.ts
+++ b/src/commands/setup.ts
@@ -68,7 +68,12 @@ export const isAzCLIInstall = async (): Promise<void> => {
     const ver = result
       .split("\n")
       .find((s) => s.startsWith("azure-cli "))
-      ?.split(/\s+/);
+      ?.replace(/\*$/, "")
+      .trim()
+      .split(/\s+/);
+    // need to remove trailing *, i got
+    // azure-cli  2.5.0 *
+    // for the version of az cli that I have
     const version = ver && ver.length === 2 ? ver[1] : null;
 
     if (version) {


### PR DESCRIPTION
closes https://github.com/microsoft/bedrock-cli/issues/34

for some az cli tool, az --version returns
```
azure-cli                          2.5.0 *
...
```
an * at the end of the version number.

This causes `bedrock setup` unable to detect the az cli's version; and quit