### PR TITLE
Add branch mapping to rings

### DIFF
--- a/docs/commands/data.json
+++ b/docs/commands/data.json
@@ -531,6 +531,13 @@
     "command": "create <ring-name>",
     "alias": "c",
     "description": "Create a new ring for the current working directory project repository. This will affect all services within the project repository.",
+    "options": [
+      {
+        "arg": "--target-branch <branch-name>",
+        "description": "The target branch this ring will map to; defaults to <ring-name> if not provided.",
+        "defaultValue": ""
+      }
+    ],
     "markdown": "## Description\n\nBedrock command to create a ring into an initialized bedrock project.\n\n## Example\n\nFor a bedrock.yaml file that looks like this:\n\n```yaml\nrings:\n  dev:\n    isDefault: true\n  qa:\n  prod:\nservices:\n  - path: ./\n    displayName: \"fabrikam\"\n    helm:\n      chart:\n        branch: master\n        git: \"https://dev.azure.com/fabrikam/frontend/_git/charts\"\n        path: frontend\n    k8sBackend: \"fabrikam-k8s-svc\"\n    k8sBackendPort: 80\n    middlewares: []\n    pathPrefix: \"fabrikam-service\"\n    pathPrefixMajorVersion: \"v1\"\nvariableGroups:\n  - fabrikam-vg\n```\n\nrunning `bedrock ring create stage` will result in a few changes:\n\n1. `stage` will be added into `bedrock.yaml` rings component:\n   ```yaml\n   rings:\n   dev:\n     isDefault: true\n   qa:\n   prod:\n   stage:\n   services:\n     - path: ./\n       displayName: \"fabrikam\"\n       helm:\n       chart:\n         branch: master\n         git: \"https://dev.azure.com/fabrikam/frontend/_git/charts\"\n         path: frontend\n       k8sBackend: \"fabrikam-k8s-svc\"\n       k8sBackendPort: 80\n       middlewares: []\n       pathPrefix: \"fabrikam-service\"\n       pathPrefixMajorVersion: \"v1\"\n   variableGroups:\n     - fabrikam-vg\n   ```\n2. Each of the referenced services within `bedrock.yaml` will have their\n   `build-update-hld.yaml` updated to include the new ring, `stage` in their\n   branch triggers:\n\n   ```yaml\n    trigger:\n    branches:\n        include:\n        - dev\n        - qa\n        - prod\n        - stage <-- NEW -->\n    variables:\n    - group: fabrikam-vg\n    …\n   ```\n\n3. Commiting these changes will trigger the project's lifecycle pipeline, which\n   will then scaffold out the newly created ring, along with the appropriate\n   IngressRoutes in the linked HLD repository.\n"
   },
   "ring delete": {

--- a/src/commands/ring/create.decorator.json
+++ b/src/commands/ring/create.decorator.json
@@ -1,5 +1,12 @@
 {
   "command": "create <ring-name>",
   "alias": "c",
-  "description": "Create a new ring for the current working directory project repository. This will affect all services within the project repository."
+  "description": "Create a new ring for the current working directory project repository. This will affect all services within the project repository.",
+  "options": [
+    {
+      "arg": "--target-branch <branch-name>",
+      "description": "The target branch this ring will map to; defaults to <ring-name> if not provided.",
+      "defaultValue": ""
+    }
+  ]
 }

--- a/src/commands/ring/create.test.ts
+++ b/src/commands/ring/create.test.ts
@@ -59,14 +59,19 @@ describe("checkDependencies", () => {
 describe("test execute function and logic", () => {
   it("test execute function: missing ring input", async () => {
     const exitFn = jest.fn();
-    await execute("", "someprojectpath", exitFn);
+    await execute("", "someprojectpath", { targetBranch: "" }, exitFn);
     expect(exitFn).toBeCalledTimes(1);
     expect(exitFn.mock.calls).toEqual([[1]]);
   });
   it("test execute function: invalid ring input", async () => {
     const exitFn = jest.fn();
     jest.spyOn(dns, "assertIsValid");
-    await execute("-not!dns@compliant%", "someprojectpath", exitFn);
+    await execute(
+      "-not!dns@compliant%",
+      "someprojectpath",
+      { targetBranch: "" },
+      exitFn
+    );
     expect(dns.assertIsValid).toHaveReturnedTimes(0); // should never return because it throws
     expect(exitFn).toBeCalledTimes(1);
     expect(exitFn.mock.calls).toEqual([[1]]);
@@ -74,7 +79,7 @@ describe("test execute function and logic", () => {
   it("test execute function: missing project path", async () => {
     const exitFn = jest.fn();
     jest.spyOn(dns, "assertIsValid");
-    await execute("ring", "", exitFn);
+    await execute("ring", "", { targetBranch: "" }, exitFn);
     expect(dns.assertIsValid).toHaveReturnedTimes(1);
     expect(exitFn).toBeCalledTimes(1);
     expect(exitFn.mock.calls).toEqual([[1]]);
@@ -117,7 +122,7 @@ describe("test execute function and logic", () => {
       Object.entries(oldBedrockFile.rings).map(([ring]) => ring)
     ).not.toContain(newRingName);
 
-    await execute(newRingName, tmpDir, exitFn);
+    await execute(newRingName, tmpDir, { targetBranch: "" }, exitFn);
 
     const updatedBedrockFile: BedrockFile = loadBedrockFile(tmpDir);
     expect(

--- a/src/commands/ring/delete.ts
+++ b/src/commands/ring/delete.ts
@@ -55,7 +55,9 @@ export const execute = async (
     bedrock.create(projectPath, bedrockWithoutRing);
 
     // Delete ring from all linked service build pipelines' branch triggers
-    const ringBranches = Object.keys(bedrockWithoutRing.rings);
+    const ringBranches = Object.entries(bedrockWithoutRing.rings).map(
+      ([ring, config]) => config.targetBranch || ring
+    );
     for (const { path: servicePath } of bedrockConfig.services) {
       updateTriggerBranchesForServiceBuildAndUpdatePipeline(
         ringBranches,

--- a/src/lib/bedrockYaml/bedrockYaml.ts
+++ b/src/lib/bedrockYaml/bedrockYaml.ts
@@ -162,19 +162,32 @@ export const setDefaultRing = (
 
   create(dir, bedrockFile);
 };
+
 /**
  * Update bedrock.yaml with new ring
  *
  * @param dir Directory where <code>bedrock.yaml</code> file resides.
  * @param ringName ring to be added.
  */
-export const addNewRing = (dir: string, ringName: string): void => {
+export const addNewRing = (
+  dir: string,
+  ringName: string,
+  opts: RingConfig = {}
+): void => {
   const absPath = path.resolve(dir);
-  const data: BedrockFile = read(absPath);
+  const currentBedrock: BedrockFile = read(absPath);
+  const newBedrock = {
+    ...currentBedrock,
+    rings: {
+      ...currentBedrock.rings,
+      [ringName]: {
+        targetBranch: ringName,
+        ...opts,
+      },
+    },
+  };
 
-  data.rings[ringName] = {}; // Alternatively, we can set isDefault = false or some passable value.
-
-  const asYaml = yaml.safeDump(data, {
+  const asYaml = yaml.safeDump(newBedrock, {
     lineWidth: Number.MAX_SAFE_INTEGER,
   });
   fs.writeFileSync(path.join(absPath, YAML_NAME), asYaml);

--- a/src/types.d.ts
+++ b/src/types.d.ts
@@ -44,7 +44,8 @@ export interface Rings {
 }
 
 export interface RingConfig {
-  isDefault?: boolean; // indicates the branch is a default branch to PR against when creating a service revision
+  isDefault?: boolean; // indicates the branch is a default branch to PR against when creating a service revision,
+  targetBranch?: string; // the branch this ring maps to; if not present defaults to the key which maps to this RingConfig
 }
 
 /**

--- a/tests/validations.sh
+++ b/tests/validations.sh
@@ -389,6 +389,7 @@ git pull
 hld_repo_commit_id=$(git log --format="%H" -n 1)
 verify_pipeline_with_poll_and_source_version $AZDO_ORG_URL $AZDO_PROJECT $hld_to_manifest_pipeline_name 500 15 $hld_repo_commit_id
 ring_name=qa-ring
+branch_name="qa-target-branch"
 
 cd $TEST_WORKSPACE
 cd $mono_repo_dir
@@ -396,9 +397,9 @@ cd $mono_repo_dir
 echo "Create ring"
 git checkout master
 git pull origin master
-bedrock ring create $ring_name
+bedrock ring create $ring_name --target-branch $branch_name
 git add -A
-git commit -m "Adding test ring: $ring_name"
+git commit -m "Adding test ring '$ring_name' --target-branch '$branch_name'"
 git push -u origin --all
 
 # Wait for the lifecycle pipeline to finish and approve the pull request
@@ -438,13 +439,13 @@ echo "Successfully created ring: $ring_name."
 echo "Update ring."
 cd $TEST_WORKSPACE
 cd $mono_repo_dir
-git branch $ring_name
-git checkout $ring_name
+git branch $branch_name
+git checkout $branch_name
 cd services/$FrontEnd
 echo "Ring doc" >> ringDoc.md
 git add ringDoc.md
 git commit -m "Adding ring doc file"
-git push --set-upstream origin $ring_name
+git push --set-upstream origin $branch_name
 mono_repo_commit_id=$(git log --format="%H" -n 1)
 
 # Verify frontend service pipeline run was successful
@@ -523,6 +524,7 @@ if [ -d "$ring_dir" ]; then
 fi
 
 echo "Successfully deleted ring: $ring_name."
+
 
 
 echo "Successfully reached the end of the service validations scripts."


### PR DESCRIPTION
**THIS PR IS INCOMPLETE -- SEEKING FEEDBACK**

This PR is an initial attempt to add the ability to map custom branches to
rings. After investigation and attempts at implementation, I've come to the
conclusion that without a major refactor to the service-build-update pipeline,
adding this functionality cannot be done cleanly.

Problems:

- The build-update pipeline has no way to map its trigger branch back to a ring.
  - It doesn't know which directory it needs to `cd` into prior to calling
    `fab set` to update the image tag.
- Multiple rings can map to the same branch. Meaning that the build-update
  pipeline would need to be able to update multiple rings -- requiring parsing
  of bedrock.yaml.

To get around this problems, we would need to the ability to parse the
bedrock.yaml file in the build-update pipeline. To do so, we would need to
implement a pseudo `hld reconcile`-like function which would be called in the
pipeline -- meaning the build-update pipeline would require the bedrock-cli as
well (just like the lifecycle pipeline).

I do not believe that the additional functionally of target branches for rings
worth this jump in complexity for hte pipeline.

closes https://github.com/microsoft/bedrock/issues/1313