### PR TITLE
Adds `shell: true` to the spawn options on Windows

### DIFF
--- a/src/lib/shell.ts
+++ b/src/lib/shell.ts
@@ -22,6 +22,9 @@ export const exec = async (
   opts: child_process.SpawnOptions = {}
 ): Promise<string> => {
   return new Promise<string>((resolve, reject) => {
+    if (process.platform === "win32") {
+      opts = { ...opts, shell: true };
+    }
     const child = child_process.spawn(cmd, args, opts);
     const cmdString = `${cmd} ${args.join(" ")}`;
     let stdout = "";


### PR DESCRIPTION
Currently `bedrock-cli` cannot run on windows even when `az` is installed as #58 pointed out.
The commit adds `shell: true` to the spawn option which fixes the issue.